### PR TITLE
Added Parallelisation to containment check to speed up geometry build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 pName=jts-utils
 pGroup=de.topobyte
-pVersion=0.4.0
+pVersion=0.4.1

--- a/src/main/java/de/topobyte/jts/utils/PolygonHelper.java
+++ b/src/main/java/de/topobyte/jts/utils/PolygonHelper.java
@@ -138,12 +138,9 @@ public class PolygonHelper
 			candidates.addAll(rings);
 			candidates.remove(r);
 			Polygon p1 = ringToPolygon.get(r);
-			for (LinearRing c : candidates) {
-				Polygon p2 = ringToPolygon.get(c);
-				if (p1.contains(p2)) {
-					graph.addEdge(r, c);
-				}
-			}
+			candidates.parallelStream().
+					filter(c -> p1.contains(ringToPolygon.get(c))).
+					forEach(c -> graph.addEdge(r, c));
 		}
 
 		// Assemble polygons with holes based on degree of the nodes

--- a/src/main/java/de/topobyte/jts/utils/PolygonHelper.java
+++ b/src/main/java/de/topobyte/jts/utils/PolygonHelper.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -138,9 +139,9 @@ public class PolygonHelper
 			candidates.addAll(rings);
 			candidates.remove(r);
 			Polygon p1 = ringToPolygon.get(r);
-			candidates.parallelStream().
-					filter(c -> p1.contains(ringToPolygon.get(c))).
-					forEach(c -> graph.addEdge(r, c));
+			List<LinearRing> containedRings = candidates.parallelStream().
+					filter(c -> p1.contains(ringToPolygon.get(c))).collect(Collectors.toList());
+			containedRings.forEach(c -> graph.addEdge(r, c));
 		}
 
 		// Assemble polygons with holes based on degree of the nodes


### PR DESCRIPTION
Parallelization is implemented in creating MultiPolygon from linear Rings. Based on the profiling, it is seen that some large osm entities (like big lakes eg. [Merowe Reservoir](https://www.openstreetmap.org/relation/2937979) ) take too much time to build geometry. Parallelization decreases build time by 80% (depending on the machine, in this case, 8 CPU & 16GB memory compared with multithreaded vs single-threaded)